### PR TITLE
removed /1e18 and used from_wei

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.0.16"
+version = "0.0.17"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/firefly_exchange_client.py
+++ b/src/firefly_exchange_client.py
@@ -503,7 +503,7 @@ class FireflyClient:
         """
         try:
             contract = self.contracts.get_contract(name="MarginBank")
-            return contract.functions.getAccountBankBalance(self.account.address).call()/1e18
+            return from_wei(contract.functions.getAccountBankBalance(self.account.address).call(),"ether")
         except Exception as e:
             raise(Exception("Failed to get balance, Exception: {}".format(e)))
 


### PR DESCRIPTION
## Description 
get_margin_bank_balance was dividing bigNumber by 1e18 to convert to base 10. Replaced divide by 1e18 by ether utils function from_wei
[QUANT-454](https://linear.app/seed/issue/QUANT-454/firefly-client-python-get-margin-bank-balance-use-from-wei-instead-of)
 