### PR TITLE
[QUANT-492] [EXC-715] Async Calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
+        "aiohttp",
         "ARBITRUM",
+        "asyncio",
         "BOBA",
         "dapi",
         "hexstr",

--- a/README.md
+++ b/README.md
@@ -40,28 +40,37 @@ For testing purposes use `Networks[TESTNET_ARBITRUM]` and for production please 
 ​
 ​
 ```python
+from config import TEST_ACCT_KEY, TEST_NETWORK
 from firefly_exchange_client import FireflyClient
 from constants import Networks
 from pprint import pprint
-​import asyncio
+import asyncio
 
-# initialize client
-client = FireflyClient(
+async def main():
+  # initialize client
+  client = FireflyClient(
       True, # agree to terms and conditions
-      Networks["TESTNET_ARBITRUM"], # network to connect with e.g. TESTNET_ARBITRUM | MAINNET_ARBITRUM
-      "0x.....", # PK for the account
-      True, # on boards user on firefly. Must be set to true for first time use
+      Networks[TEST_NETWORK], # network to connect with
+      TEST_ACCT_KEY, # private key of wallet
       )
-​
-print('Account Address:', client.get_public_address());
-​
-# # gets user account data on-chain
-# if running in async method
-data = await client.get_user_account_data() 
-# if running in a sync method
-# data = asyncio.run(client.get_user_account_data())
-​
-pprint(data)
+
+  # initialize the client
+  # on boards user on firefly. Must be set to true for first time use
+  await client.init(True) 
+  
+  print('Account Address:', client.get_public_address());
+
+  # # gets user account data on-chain
+  data = await client.get_user_account_data()
+
+  # close aio http connection
+  await client.apis.close_session()
+
+  pprint(data)
+
+if __name__ == "__main__":
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())
 ```
 ​
 **Placing Orders:**
@@ -74,7 +83,8 @@ from interfaces import OrderSignatureRequest
 
 # initialize
 client = FireflyClient(....) 
-​
+​client.init(True)
+
 # creates a LIMIT order to be signed
 signature_request = OrderSignatureRequest(
     symbol=MARKET_SYMBOLS.ETH,  # market symbol
@@ -108,7 +118,8 @@ def callback(event):
 ​
 # initialize
 client = FireflyClient(....) 
-​
+​client.init(True)
+
 # make connection with firefly exchange
 await client.socket.open()
 ​
@@ -146,6 +157,7 @@ def callback(event):
 
 # initialize
 client = FireflyClient(....) 
+client.init()
 
 # make connection with firefly exchange
 client.webSocketClient.initialize_socket(on_open=on_open)

--- a/examples/1.initializaiton.py
+++ b/examples/1.initializaiton.py
@@ -4,21 +4,30 @@ from constants import Networks
 from pprint import pprint
 import asyncio
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
+
 
 async def main():
+  # initialize client
+  client = FireflyClient(
+      True, # agree to terms and conditions
+      Networks[TEST_NETWORK], # network to connect with
+      TEST_ACCT_KEY, # private key of wallet
+      )
+
+  # initialize the client
+  # on boards user on firefly. Must be set to true for first time use
+  await client.init(True) 
+  
   print('Account Address:', client.get_public_address());
 
   # # gets user account data on-chain
   data = await client.get_user_account_data()
 
+  # close aio http connection
+  await client.apis.close_session()
+
   pprint(data)
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/10.sockets.py
+++ b/examples/10.sockets.py
@@ -22,7 +22,7 @@ async def main():
   print("Subscribed to global BTC events: {}".format(status))
 
   # subscribe to local user events
-  client.socket.subscribe_user_update_by_token()
+  await client.socket.subscribe_user_update_by_token()
   print("Subscribed to user events")
 
   # triggered when order book updates

--- a/examples/10.sockets.py
+++ b/examples/10.sockets.py
@@ -5,19 +5,13 @@ from constants import Networks
 from enumerations import MARKET_SYMBOLS, SOCKET_EVENTS
 import asyncio
 
-
-# initialize client
-client = FireflyClient(
-      True, # agree to terms and conditions
-      Networks[TEST_NETWORK], # network to connect with
-      TEST_ACCT_KEY, # private key of wallet
-      True, # on boards user on firefly. Must be set to true for first time use
-      )
-
 def callback(event):
     print("Event data:", event)
 
 async def main():
+
+  client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+  await client.init(True)
 
   # must open socket before subscribing
   print("Making socket connection to firefly exchange")
@@ -58,6 +52,10 @@ async def main():
   print("Closing sockets!")
   await client.socket.close()
 
+  await client.apis.close_session();
+
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/11.sub_accounts.py
+++ b/examples/11.sub_accounts.py
@@ -25,6 +25,8 @@ async def main():
 
   clientChild.add_market(MARKET_SYMBOLS.ETH)
 
+  parent_leverage =  await clientParent.get_user_leverage(MARKET_SYMBOLS.ETH)
+
   signature_request = OrderSignatureRequest(
         symbol=MARKET_SYMBOLS.ETH, # sub account is only whitelisted for ETH market
         maker=clientParent.get_public_address(),  # maker of the order is the parent account
@@ -32,12 +34,11 @@ async def main():
         quantity=0.02,
         side=ORDER_SIDE.BUY, 
         orderType=ORDER_TYPE.MARKET,
-        leverage=3,
+        leverage=parent_leverage,
     )  
 
   # order is signed using sub account's private key
   signed_order = clientChild.create_signed_order(signature_request);
-
 
   resp = await clientChild.post_signed_order(signed_order)
 

--- a/examples/11.sub_accounts.py
+++ b/examples/11.sub_accounts.py
@@ -5,24 +5,14 @@ from constants import Networks
 from interfaces import OrderSignatureRequest
 import asyncio
 
-# initialize client with parent account
-clientParent = FireflyClient(
-      True, 
-      Networks[TEST_NETWORK], 
-      TEST_ACCT_KEY,
-      True,
-      )
-
-
-# initialize client with sub account key
-clientChild = FireflyClient(
-      True,
-      Networks[TEST_NETWORK], 
-      TEST_SUB_ACCT_KEY, 
-      True,
-      )
 
 async def main():
+
+  clientParent = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+  await clientParent.init(True)
+
+  clientChild = FireflyClient(True, Networks[TEST_NETWORK], TEST_SUB_ACCT_KEY)
+  await clientChild.init(True)
 
   print("Parent: ", clientParent.get_public_address())
 
@@ -53,5 +43,10 @@ async def main():
 
   print(resp)
 
+  await clientChild.apis.close_session();
+  await clientParent.apis.close_session();
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/13.orderbook_updates.py
+++ b/examples/13.orderbook_updates.py
@@ -10,26 +10,9 @@ from interfaces import OrderSignatureRequest
 from enumerations import MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE
 import asyncio
 
-client:FireflyClient = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
 
-client.add_market(MARKET_SYMBOLS.ETH)
 
-def callback(event):
-    print("Event data:", event)
-    
-    status = asyncio.run(client.socket.unsubscribe_global_updates_by_symbol(MARKET_SYMBOLS.ETH))
-    print("Unsubscribed from orderbook update events for ETH Market: {}".format(status))
-
-    # close socket connection
-    print("Closing sockets!")
-    asyncio.run(client.socket.close())
-
-async def place_limit_order():
+async def place_limit_order(client:FireflyClient):
        
     # default leverage of account is set to 3 on firefly
     user_leverage = await client.get_user_leverage(MARKET_SYMBOLS.ETH)
@@ -56,6 +39,22 @@ async def place_limit_order():
 
 async def main():
 
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
+    
+    client.add_market(MARKET_SYMBOLS.ETH)
+
+    def callback(event):
+        print("Event data:", event)
+    
+        status = asyncio.run(client.socket.unsubscribe_global_updates_by_symbol(MARKET_SYMBOLS.ETH))
+        print("Unsubscribed from orderbook update events for ETH Market: {}".format(status))
+
+        # close socket connection
+        print("Closing sockets!")
+        asyncio.run(client.socket.close())
+
+
     # must open socket before subscribing
     print("Making socket connection to firefly exchange")
     await client.socket.open()
@@ -67,8 +66,12 @@ async def main():
     print("Listening to ETH Orderbook update event")
     await client.socket.listen(SOCKET_EVENTS.ORDERBOOK_UPDATE.value, callback)
 
-    await place_limit_order();
+    await place_limit_order(client);
+
+    await client.apis.close_session();
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())
 

--- a/examples/14.web_sockets.py
+++ b/examples/14.web_sockets.py
@@ -9,64 +9,62 @@ from utilities import config_logging
 
 config_logging(logging, logging.DEBUG)
 
-# initialize client
-client = FireflyClient(
-      True, # agree to terms and conditions
-      Networks[TEST_NETWORK], # network to connect with
-      TEST_ACCT_KEY, # private key of wallet
-      True, # on boards user on firefly. Must be set to true for first time use
-      )
 
 def callback(event):
     print("Event data:", event)
 
 async def main():
+   client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+   await client.init(True)
+   
+   def on_error(ws, error):
+        print(error)
+        
+   def on_close(ws, close_status_code, close_msg):
+        print("### closed ###")
+    
+   def on_open(ws):
+        # subscribe to global event updates for BTC market 
+        status = client.webSocketClient.subscribe_global_updates_by_symbol(MARKET_SYMBOLS.BTC)
+        print("Subscribed to global BTC events: {}".format(status))
 
-  # must open socket before subscribing
-  print("Making socket connection to firefly exchange")
-  client.webSocketClient.initialize_socket(on_open=on_open, on_error=on_error,on_close=on_close)
+        # subscribe to local user events
+        client.webSocketClient.subscribe_user_update_by_token()
+        print("Subscribed to user events")
 
-def on_open(ws):
-   # subscribe to global event updates for BTC market 
-  status = client.webSocketClient.subscribe_global_updates_by_symbol(MARKET_SYMBOLS.BTC)
-  print("Subscribed to global BTC events: {}".format(status))
+        # triggered when order book updates
+        print("Listening to Orderbook updates")
+        client.webSocketClient.listen(SOCKET_EVENTS.ORDERBOOK_UPDATE.value, callback)
 
-  # subscribe to local user events
-  client.webSocketClient.subscribe_user_update_by_token()
-  print("Subscribed to user events")
+        # triggered when status of any user order updates
+        print("Listening to user order updates")
+        client.webSocketClient.listen(SOCKET_EVENTS.ORDER_UPDATE.value, callback)
 
-  # triggered when order book updates
-  print("Listening to Orderbook updates")
-  client.webSocketClient.listen(SOCKET_EVENTS.ORDERBOOK_UPDATE.value, callback)
+        # SOCKET_EVENTS contains all events that can be listened to
+        
+        # logs event name and data for all markets and users that are subscribed.
+        # helpful for debugging
+        # client.socket.listen("default",callback)
 
-  # triggered when status of any user order updates
-  print("Listening to user order updates")
-  client.webSocketClient.listen(SOCKET_EVENTS.ORDER_UPDATE.value, callback)
+        time.sleep(60)
+        # unsubscribe from global events
+        status = client.webSocketClient.unsubscribe_global_updates_by_symbol(MARKET_SYMBOLS.BTC)
+        print("Unsubscribed from global BTC events: {}".format(status))
 
-  # SOCKET_EVENTS contains all events that can be listened to
-  
-  # logs event name and data for all markets and users that are subscribed.
-  # helpful for debugging
-  # client.socket.listen("default",callback)
-
-  time.sleep(60)
-  # unsubscribe from global events
-  status = client.webSocketClient.unsubscribe_global_updates_by_symbol(MARKET_SYMBOLS.BTC)
-  print("Unsubscribed from global BTC events: {}".format(status))
-
-  status = client.webSocketClient.unsubscribe_user_update_by_token()
-  print("Unsubscribed from user events: {}".format(status))
+        status = client.webSocketClient.unsubscribe_user_update_by_token()
+        print("Unsubscribed from user events: {}".format(status))
 
 
-  # close socket connection
-  print("Closing sockets!")
-  client.webSocketClient.stop()
+        # close socket connection
+        print("Closing sockets!")
+        client.webSocketClient.stop()
 
-def on_error(ws, error):
-    print(error)
-
-def on_close(ws, close_status_code, close_msg):
-    print("### closed ###")
+    
+   print("Making socket connection to firefly exchange")
+   client.webSocketClient.initialize_socket(on_open=on_open, on_error=on_error,on_close=on_close)
+   
+   await client.apis.close_session();
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/15.get_funding_history.py
+++ b/examples/15.get_funding_history.py
@@ -4,18 +4,12 @@ from constants import Networks
 from enumerations import MARKET_SYMBOLS
 from pprint import pprint
 import asyncio
-
 from interfaces import GetFundingHistoryRequest
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-)
-
 async def main():
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
+ 
 
     # create a funding history request
     funding_history_request = GetFundingHistoryRequest(
@@ -30,6 +24,9 @@ async def main():
     # returns funding history response
     pprint(funding_history_response)
 
+    await client.apis.close_session();
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/15.get_funding_history.py
+++ b/examples/15.get_funding_history.py
@@ -1,0 +1,35 @@
+from config import TEST_ACCT_KEY, TEST_NETWORK
+from firefly_exchange_client import FireflyClient
+from constants import Networks
+from enumerations import MARKET_SYMBOLS
+from pprint import pprint
+import asyncio
+
+from interfaces import GetFundingHistoryRequest
+
+# initialize client
+client = FireflyClient(
+    True, # agree to terms and conditions
+    Networks[TEST_NETWORK], # network to connect with
+    TEST_ACCT_KEY, # private key of wallet
+    True, # on boards user on firefly. Must be set to true for first time use
+)
+
+async def main():
+
+    # create a funding history request
+    funding_history_request = GetFundingHistoryRequest(
+        symbol=MARKET_SYMBOLS.ETH,  # market symbol
+        pageSize=50, # gets provided number of payments <= 50
+        cursor=0 # fetch a particular page. A single page contains upto 50 records
+    )
+
+    # submit request for funding history
+    funding_history_response = await client.get_funding_history(funding_history_request)
+
+    # returns funding history response
+    pprint(funding_history_response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/2.user_info.py
+++ b/examples/2.user_info.py
@@ -5,15 +5,18 @@ from enumerations import MARKET_SYMBOLS
 from pprint import pprint
 import asyncio
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
 
 async def main():
+    # create client instance
+    client = FireflyClient(
+        True, # agree to terms and conditions
+        Networks[TEST_NETWORK], # network to connect with
+        TEST_ACCT_KEY, # private key of wallet
+        )
+    
+    # initialize the client
+    # on boards user on firefly. Must be set to true for first time use
+    await client.init(True) 
 
     # gets user account data on firefly exchange
     data = await client.get_user_account_data()
@@ -30,6 +33,10 @@ async def main():
     # returns user position if exists
     pprint(position)
 
+    await client.apis.close_session();
+    
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/3.balance.py
+++ b/examples/3.balance.py
@@ -3,15 +3,21 @@ from firefly_exchange_client import FireflyClient
 from constants import Networks
 import asyncio
 
-# initialize client
-client = FireflyClient(
-      True, # agree to terms and conditions
-      Networks[TEST_NETWORK], # network to connect with
-      TEST_ACCT_KEY, # private key of wallet
-      True, # on boards user on firefly. Must be set to true for first time use
-      )
+
+
 
 async def main():
+   # create client instance
+  client = FireflyClient(
+        True, # agree to terms and conditions
+        Networks[TEST_NETWORK], # network to connect with
+        TEST_ACCT_KEY, # private key of wallet
+        )
+    
+  # initialize the client
+  # on boards user on firefly. Must be set to true for first time use
+  await client.init(True) 
+
   # checks chain native token balance.
   # A user must have native tokens to perform contract calls
   print('Chain token balance:', await client.get_native_chain_token_balance());
@@ -35,5 +41,9 @@ async def main():
   # check margin bank balance
   print('Margin bank balance:', await client.get_margin_bank_balance());
 
+  await client.apis.close_session();
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/4.placing_orders.py
+++ b/examples/4.placing_orders.py
@@ -78,7 +78,7 @@ async def main():
     client.add_market(MARKET_SYMBOLS.ETH)
 
     await place_limit_order(client)
-    # await place_market_order(client)
+    await place_market_order(client)
     
     await client.apis.close_session();
 

--- a/examples/4.placing_orders.py
+++ b/examples/4.placing_orders.py
@@ -5,18 +5,9 @@ from enumerations import MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE
 from interfaces import OrderSignatureRequest
 import asyncio
 
- # initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
 
-# add market that you wish to trade on ETH/BTC are supported currently
-client.add_market(MARKET_SYMBOLS.ETH)
 
-async def place_limit_order():
+async def place_limit_order(client: FireflyClient):
    
     # default leverage of account is set to 3 on firefly
     user_leverage = await client.get_user_leverage(MARKET_SYMBOLS.ETH)
@@ -43,7 +34,7 @@ async def place_limit_order():
 
     return
 
-async def place_market_order():
+async def place_market_order(client: FireflyClient):
     
 
     # default leverage of account is set to 3 on firefly
@@ -73,9 +64,25 @@ async def place_market_order():
     return
 
 async def main():
-    await place_limit_order()
-    await place_market_order()
+
+    # initialize client
+    client = FireflyClient(
+        True, # agree to terms and conditions
+        Networks[TEST_NETWORK], # network to connect with
+        TEST_ACCT_KEY, # private key of wallet
+        )
+
+    await client.init(True) 
+
+    # add market that you wish to trade on ETH/BTC are supported currently
+    client.add_market(MARKET_SYMBOLS.ETH)
+
+    await place_limit_order(client)
+    # await place_market_order(client)
     
+    await client.apis.close_session();
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/5.adjusting_leverage.py
+++ b/examples/5.adjusting_leverage.py
@@ -5,16 +5,18 @@ from enumerations import MARKET_SYMBOLS
 import asyncio
 
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
+
 
 async def main():
 
+    # initialize client
+    client = FireflyClient(
+        True, # agree to terms and conditions
+        Networks[TEST_NETWORK], # network to connect with
+        TEST_ACCT_KEY, # private key of wallet
+    )
+
+    await client.init(True) 
 
     print('Leverage on BTC market:', await client.get_user_leverage(MARKET_SYMBOLS.BTC))
     # we have a position on BTC so this will perform on-chain leverage update
@@ -30,7 +32,8 @@ async def main():
 
     print('Leverage on ETH market:', await client.get_user_leverage(MARKET_SYMBOLS.ETH))
 
-
+    await client.apis.close_session();
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/6.adjusting_margin.py
+++ b/examples/6.adjusting_margin.py
@@ -5,43 +5,42 @@ from enumerations import MARKET_SYMBOLS, ADJUST_MARGIN
 from eth_utils import from_wei
 import asyncio
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
 
 async def main():
 
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
 
-    
-    position = await client.get_user_position({"symbol":MARKET_SYMBOLS.BTC});
-    print("Current margin in position:", from_wei(position["margin"], "ether"))
+    position = await client.get_user_position({"symbol":MARKET_SYMBOLS.ETH});
+    print("Current margin in position:", from_wei(int(position["margin"]), "ether"))
 
     # adding 100$ from our margin bank into our BTC position on-chain
     # must have native chain tokens to pay for gas fee
-    await client.adjust_margin(MARKET_SYMBOLS.BTC, ADJUST_MARGIN.ADD, 100);
+    await client.adjust_margin(MARKET_SYMBOLS.ETH, ADJUST_MARGIN.ADD, 100);
 
     # get updated position margin. Note it can take a few seconds to show updates
     # to on-chain positions on exchange as off-chain infrastructure waits for blockchain
     # to emit position update event
-    position = await client.get_user_position({"symbol":MARKET_SYMBOLS.BTC});
-    print("Current margin in position:", from_wei(position["margin"], "ether"))
+    position = await client.get_user_position({"symbol":MARKET_SYMBOLS.ETH});
+    print("Current margin in position:", from_wei(int(position["margin"]), "ether"))
 
 
     # removing 100$ from margin
-    await client.adjust_margin(MARKET_SYMBOLS.BTC, ADJUST_MARGIN.REMOVE, 100);
+    await client.adjust_margin(MARKET_SYMBOLS.ETH, ADJUST_MARGIN.REMOVE, 100);
 
-    position = await client.get_user_position({"symbol":MARKET_SYMBOLS.BTC});
-    print("Current margin in position:", from_wei(position["margin"], "ether"))
+    position = await client.get_user_position({"symbol":MARKET_SYMBOLS.ETH});
+    print("Current margin in position:", from_wei(int(position["margin"]), "ether"))
 
 
-    # will throw as user does not have any open position on ETH to adjust margin on
-    await client.adjust_margin(MARKET_SYMBOLS.ETH, ADJUST_MARGIN.ADD, 100);
+    try:
+        # will throw as user does not have any open position on BTC to adjust margin on
+        await client.adjust_margin(MARKET_SYMBOLS.BTC, ADJUST_MARGIN.ADD, 100);
+    except Exception as e:
+        print("Error:", e)
 
+    await client.apis.close_session();
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/7.cancelling_orders.py
+++ b/examples/7.cancelling_orders.py
@@ -6,22 +6,14 @@ from enumerations import MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE
 from pprint import pprint
 import asyncio
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
 
 async def main():
 
-
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
 
     # must add market before cancelling its orders
     client.add_market(MARKET_SYMBOLS.ETH)
-
-
 
     order = {
         "symbol":MARKET_SYMBOLS.ETH, 
@@ -63,5 +55,9 @@ async def main():
     else:
         pprint(resp)
 
+    await client.apis.close_session();
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/8.exchange_data.py
+++ b/examples/8.exchange_data.py
@@ -4,17 +4,11 @@ from constants import Networks
 from enumerations import MARKET_SYMBOLS, Interval, TRADE_TYPE
 from pprint import pprint
 import asyncio
-
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
     
 async def main():
 
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
 
 
     # returns status/health of exchange
@@ -60,5 +54,9 @@ async def main():
     contract_address = client.get_contract_addresses()
     pprint(contract_address)
 
+    await client.apis.close_session();
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/examples/8.exchange_data.py
+++ b/examples/8.exchange_data.py
@@ -51,7 +51,7 @@ async def main():
 
 
     # gets addresses of on-chain contracts
-    contract_address = client.get_contract_addresses()
+    contract_address = await client.get_contract_addresses()
     pprint(contract_address)
 
     await client.apis.close_session();

--- a/examples/9.user_data.py
+++ b/examples/9.user_data.py
@@ -5,16 +5,10 @@ from enumerations import MARKET_SYMBOLS, ORDER_STATUS
 from pprint import pprint
 import asyncio
 
-# initialize client
-client = FireflyClient(
-    True, # agree to terms and conditions
-    Networks[TEST_NETWORK], # network to connect with
-    TEST_ACCT_KEY, # private key of wallet
-    True, # on boards user on firefly. Must be set to true for first time use
-    )
-
 async def main():
 
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
 
     
     # returns user account (having pvt key and pub address)
@@ -64,7 +58,9 @@ async def main():
     user_leverage = await client.get_user_leverage(MARKET_SYMBOLS.BTC)
     print("Account leverage:", user_leverage)    
 
-    return
+    await client.apis.close_session();
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.0.18"
+version = "0.0.19"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.0.19"
+version = "0.1.0"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/api_service.py
+++ b/src/api_service.py
@@ -23,7 +23,10 @@ class APIService():
 
         response = None
         if auth_required:
-            response = await self.client.get(url, params=query, headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
+            response = await self.client.get(
+                url, 
+                params=query, 
+                headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
         else:
             response = await self.client.get(url, params=query)
 
@@ -43,17 +46,19 @@ class APIService():
         url = self._create_url(service_url)
         response = None
 
-
         if auth_required:
-            response = await self.client.post(url=url, json=data, headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
+            response = await self.client.post(
+                url=url, 
+                data=data, 
+                headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
         else:
-            response = await self.client.post(url=url, json=data)
+            response = await self.client.post(url=url, data=data)
 
         try:
             return await response.json()
         except:
             raise Exception("Error while posting to {}: {}".format(url, response))
-
+        
     async def delete(self,service_url, data, auth_required=False):
         """
             Makes a DELETE request and returns the results
@@ -66,9 +71,12 @@ class APIService():
 
         response = None
         if auth_required:
-            response = await self.client.delete(url=url, json=data, headers={'Authorization': 'Bearer {}'.format(self.auth_token)}).json()
+            response = await self.client.delete(
+                url=url, 
+                data=data, 
+                headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
         else:
-            response =  await self.client.delete(url=url, json=data).json()
+            response = await self.client.delete(url=url, data=data)
         
         try:
             return await response.json()

--- a/src/api_service.py
+++ b/src/api_service.py
@@ -1,13 +1,17 @@
-import requests
+import aiohttp
 from interfaces import *
 
 class APIService():
     def __init__(self, url):
         self.server_url = url
         self.auth_token = None
-        return
-    
-    def get(self, service_url, query, auth_required=False):
+        self.client = aiohttp.ClientSession() 
+
+    async def close_session(self):
+        if self.client is not None:
+            return await self.client.close()
+
+    async def get(self, service_url, query, auth_required=False):
         """
             Makes a GET request and returns the results
             Inputs:
@@ -16,18 +20,19 @@ class APIService():
                 - auth_required(bool): indicates whether authorization is required for the call or not.  
         """
         url = self._create_url(service_url)
+
         response = None
         if auth_required:
-            response = requests.get(url=url, params=query, headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
+            response = await self.client.get(url, params=query, headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
         else:
-            response = requests.get(url, params=query)
+            response = await self.client.get(url, params=query)
 
         try:
-            return response.json()
+            return await response.json()
         except:
             raise Exception("Error while getting {}: {}".format(url, response))
         
-    def post(self, service_url, data, auth_required=False):
+    async def post(self, service_url, data, auth_required=False):
         """
             Makes a POST request and returns the results
             Inputs:
@@ -37,18 +42,19 @@ class APIService():
         """
         url = self._create_url(service_url)
         response = None
+
+
         if auth_required:
-            response = requests.post(url=url, data=data, headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
-
+            response = await self.client.post(url=url, json=data, headers={'Authorization': 'Bearer {}'.format(self.auth_token)})
         else:
-            response = requests.post(url=url, data=data)
+            response = await self.client.post(url=url, json=data)
 
-        if "error" in response:
+        try:
+            return await response.json()
+        except:
             raise Exception("Error while posting to {}: {}".format(url, response))
-        else:
-            return response.json()
 
-    def delete(self,service_url, data, auth_required=False):
+    async def delete(self,service_url, data, auth_required=False):
         """
             Makes a DELETE request and returns the results
             Inputs:
@@ -57,10 +63,17 @@ class APIService():
                 - auth_required(bool): indicates whether authorization is required for the call or not.
         """
         url = self._create_url(service_url)
+
+        response = None
         if auth_required:
-            return requests.delete(url=url, data=data, headers={'Authorization': 'Bearer {}'.format(self.auth_token)}).json()
+            response = await self.client.delete(url=url, json=data, headers={'Authorization': 'Bearer {}'.format(self.auth_token)}).json()
         else:
-            return requests.delete(url=url, data=data).json()
+            response =  await self.client.delete(url=url, json=data).json()
+        
+        try:
+            return await response.json()
+        except:
+            raise Exception("Error while posting to {}: {}".format(url, response))
  
     '''
         Private methods

--- a/src/api_service.py
+++ b/src/api_service.py
@@ -11,7 +11,7 @@ class APIService():
         if self.client is not None:
             return await self.client.close()
 
-    async def get(self, service_url, query, auth_required=False):
+    async def get(self, service_url, query={}, auth_required=False):
         """
             Makes a GET request and returns the results
             Inputs:

--- a/src/constants.py
+++ b/src/constants.py
@@ -88,6 +88,7 @@ SERVICE_URLS = {
     "AUTHORIZE": "/authorize",
     "ADJUST_LEVERAGE": "/account/adjustLeverage",
     "FUND_GAS": "/account/fundGas",
+    "FUNDING_HISTORY": "/userFundingHistory",
   },
   "ORDERS": {
     "ORDERS": "/orders",

--- a/src/firefly_exchange_client.py
+++ b/src/firefly_exchange_client.py
@@ -752,7 +752,6 @@ class FireflyClient:
         """
         return await self.apis.get(
             service_url = SERVICE_URLS["USER"]["ACCOUNT"],
-            query = {},
             auth_required = True
         )
         

--- a/src/firefly_exchange_client.py
+++ b/src/firefly_exchange_client.py
@@ -572,6 +572,9 @@ class FireflyClient:
                     - nextCursor: the next page number
                     - data: a list of the user's funding payments
         """
+
+        params = extract_enums(params,["symbol"])
+        
         return await self.apis.get(
             SERVICE_URLS["USER"]["FUNDING_HISTORY"],
             params,

--- a/src/firefly_exchange_client.py
+++ b/src/firefly_exchange_client.py
@@ -557,7 +557,25 @@ class FireflyClient:
         return self.apis.get(
             SERVICE_URLS["MARKET"]["FUNDING_RATE"],
             {"symbol": symbol.value}
-        ) 
+        )
+
+    async def get_funding_history(self,params:GetFundingHistoryRequest):
+        """
+            Returns a list of the user's funding payments, a boolean indicating if there is/are more page(s),
+                and the next page number
+            Inputs:
+                - params(GetFundingHistoryRequest): params required to fetch funding history  
+            Returns:
+                - GetFundingHistoryResponse: 
+                    - isMoreDataAvailable: boolean indicating if there is/are more page(s)
+                    - nextCursor: the next page number
+                    - data: a list of the user's funding payments
+        """
+        return self.apis.get(
+            SERVICE_URLS["USER"]["FUNDING_HISTORY"],
+            params,
+            auth_required=True
+        )
 
     async def get_market_meta_info(self,symbol:MARKET_SYMBOLS=None):
         """

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -135,4 +135,27 @@ class GetUserTradesRequest(TypedDict):
 class GetOrderRequest(GetTransactionHistoryRequest):
   statuses:ORDER_STATUS # status of orders to be fetched
 
+class GetFundingHistoryRequest(TypedDict):
+  symbol: MARKET_SYMBOLS  # will fetch orders of provided market
+  pageSize: int  # will get only provided number of orders must be <= 50
+  cursor: int  # will fetch particular page records. A single page contains 50 records.
 
+class FundingHistoryResponse(TypedDict):
+  id: int # unique id
+  symbol: MARKET_SYMBOLS # market for which to create order
+  userAddress: str # user public address
+  quantity: int # size of position
+  time: int # created time
+  appliedFundingRate: str # funding rate percent applied
+  isFundingRatePositive: bool # was funding rate +ve or -ve
+  payment: str # amount
+  isPaymentPositive: bool # whether payment was deducted or added
+  oraclePrice: str # price from oracle
+  side: ORDER_SIDE # BUY/SELL
+  blockNumber: int # transaction block number
+  isPositionPositive: bool # is position LONG or SHORT
+
+class GetFundingHistoryResponse(TypedDict):
+  isMoreDataAvailable: bool # boolean indicating if there is more data available
+  nextCursor: int # next page number
+  data: list[FundingHistoryResponse]


### PR DESCRIPTION
- Removed async call from client constructor to fetch contract addresses
- Created `init()` function, which should be invoked after client creation to fetch contract addresses and onboard users to exchange
- Using [aiohttp](https://docs.aiohttp.org/en/stable/) for all get/post/delete API calls
- Updated examples
- Updated readme
- Bumped version to `0.1.0`