### PR TITLE
[EXC-828] Sub account features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.2.0"
+version = "0.1.3"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.1.2"
+version = "0.2.0"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/firefly_exchange_client/client.py
+++ b/src/firefly_exchange_client/client.py
@@ -746,12 +746,15 @@ class FireflyClient:
             True
         )
 
-    async def get_user_account_data(self):
+    async def get_user_account_data(self, parentAddress:str = ""):
         """
             Returns user account data.
+            Inputs:
+                - parentAddress: an optional field, used by sub accounts to fetch parent account state 
         """
         return await self.apis.get(
             service_url = SERVICE_URLS["USER"]["ACCOUNT"],
+            query = { "parentAddress": parentAddress },
             auth_required = True
         )
         

--- a/src/firefly_exchange_client/enumerations.py
+++ b/src/firefly_exchange_client/enumerations.py
@@ -15,6 +15,8 @@ class MARKET_SYMBOLS(Enum):
     LINK = "LINK-PERP"
     MATIC = "MATIC-PERP"
     DOGE = "DOGE-PERP"
+    ARB = "ARB-PERP"
+
 
 class TIME_IN_FORCE(Enum):
     FILL_OR_KILL = "FOK"

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -29,7 +29,7 @@ class OrderSignatureRequest(RequiredOrderFields):
   salt: int # (optional)  random number for uniqueness of order. Generated randomly if not provided
   expiration: int # (optional) time at which order will expire. Will be set to 1 month if not provided
   maker: str # (optional) maker of the order, if not provided the account used to initialize the client will be default maker
-  
+
 class OrderSignatureResponse(RequiredOrderFields):
   maker: str 
   orderSignature: str
@@ -99,6 +99,7 @@ class GetMarketRecentTradesRequest(TypedDict):
 class OrderCancelSignatureRequest(TypedDict):
   symbol: MARKET_SYMBOLS
   hashes: list
+  parentAddress: str # (optional) should only be provided by a sub account
 
 class OrderCancellationRequest(OrderCancelSignatureRequest):
   signature: str

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -133,7 +133,7 @@ class GetUserTradesRequest(TypedDict):
   parentAddress: str # (optional) should be provided by sub account
 
 class GetOrderRequest(GetTransactionHistoryRequest):
-  statuses:ORDER_STATUS # status of orders to be fetched
+  statuses:List[ORDER_STATUS] # status of orders to be fetched
   parentAddress : str # (optional) should be provided by sub accounts
 
 class GetFundingHistoryRequest(TypedDict):

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -122,6 +122,7 @@ class GetPositionRequest(TypedDict):
   symbol: MARKET_SYMBOLS  # will fetch orders of provided market
   pageSize: int  # will get only provided number of orders must be <= 50
   pageNumber: int  # will fetch particular page records. A single page contains 50 records.
+  parentAddress : str # (optional) should be provided by sub accounts
 
 class GetUserTradesRequest(TypedDict):
   symbol: MARKET_SYMBOLS

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -140,6 +140,8 @@ class GetFundingHistoryRequest(TypedDict):
   symbol: MARKET_SYMBOLS  # will fetch orders of provided market
   pageSize: int  # will get only provided number of orders must be <= 50
   cursor: int  # will fetch particular page records. A single page contains 50 records.
+  parentAddress: str # (optional) should be provided by a sub account 
+
 
 class FundingHistoryResponse(TypedDict):
   id: int # unique id

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -132,6 +132,7 @@ class GetUserTradesRequest(TypedDict):
   pageSize: int
   pageNumber: int
   type: ORDER_TYPE
+  parentAddress: str # (optional) should be provided by sub account
 
 class GetOrderRequest(GetTransactionHistoryRequest):
   statuses:ORDER_STATUS # status of orders to be fetched

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -118,10 +118,7 @@ class GetTransactionHistoryRequest(TypedDict):
   pageSize: int  # will get only provided number of orders must be <= 50
   pageNumber: int  # will fetch particular page records. A single page contains 50 records.
 
-class GetPositionRequest(TypedDict):
-  symbol: MARKET_SYMBOLS  # will fetch orders of provided market
-  pageSize: int  # will get only provided number of orders must be <= 50
-  pageNumber: int  # will fetch particular page records. A single page contains 50 records.
+class GetPositionRequest(GetTransactionHistoryRequest):
   parentAddress : str # (optional) should be provided by sub accounts
 
 class GetUserTradesRequest(TypedDict):
@@ -137,6 +134,7 @@ class GetUserTradesRequest(TypedDict):
 
 class GetOrderRequest(GetTransactionHistoryRequest):
   statuses:ORDER_STATUS # status of orders to be fetched
+  parentAddress : str # (optional) should be provided by sub accounts
 
 class GetFundingHistoryRequest(TypedDict):
   symbol: MARKET_SYMBOLS  # will fetch orders of provided market


### PR DESCRIPTION
Ticket: https://linear.app/seed/issue/EXC-828/coinalpha-integration-python-library-sub-account-methods
- Bumped client to `v0.1.3`
- Updated the following interfaces with an optional `parentAddress` field:
    - GetFundingHistoryRequest
    - GetOrderRequest
    - GetUserTradesRequest
    - GetPositionRequest
    - OrderCancelSignatureRequest
- Updated following methods to expect an optional `parentAddress` field
   - get_user_account_data
   - get_user_leverage
   - create_signed_cancel_order
   - create_signed_cancel_orders
   - cancel_all_open_orders
   - adjust_leverage
   - adjust_margin
- Added `ARB-PERP` to enums