### PR TITLE
Cancel All Open Orders - Extended to support any status of orders to be sent for cancellation

### DIFF
--- a/examples/7.cancelling_orders.py
+++ b/examples/7.cancelling_orders.py
@@ -1,6 +1,6 @@
 import time
 from config import TEST_ACCT_KEY, TEST_NETWORK
-from firefly_exchange_client import FireflyClient, Networks, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE
+from firefly_exchange_client import FireflyClient, Networks, MARKET_SYMBOLS, ORDER_SIDE, ORDER_TYPE, ORDER_STATUS
 from pprint import pprint
 import asyncio
 
@@ -46,7 +46,7 @@ async def main():
     pprint(resp)
 
     # cancels all open orders, returns false if there is no open order to cancel
-    resp = await client.cancel_all_open_orders(MARKET_SYMBOLS.ETH)
+    resp = await client.cancel_all_open_orders(MARKET_SYMBOLS.ETH, [ORDER_STATUS.OPEN, ORDER_STATUS.PARTIAL_FILLED])
 
     if resp == False:
         print('No open order to cancel')

--- a/examples/7.cancelling_orders.py
+++ b/examples/7.cancelling_orders.py
@@ -46,7 +46,7 @@ async def main():
     pprint(resp)
 
     # cancels all open orders, returns false if there is no open order to cancel
-    resp = await client.cancel_all_open_orders(MARKET_SYMBOLS.ETH, [ORDER_STATUS.OPEN, ORDER_STATUS.PARTIAL_FILLED])
+    resp = await client.cancel_all_orders(MARKET_SYMBOLS.ETH, [ORDER_STATUS.OPEN, ORDER_STATUS.PARTIAL_FILLED])
 
     if resp == False:
         print('No open order to cancel')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.1.3"
+version = "0.2.0"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/firefly_exchange_client/client.py
+++ b/src/firefly_exchange_client/client.py
@@ -264,12 +264,13 @@ class FireflyClient:
             auth_required=True
             )
     
-    async def cancel_all_open_orders(self,symbol:MARKET_SYMBOLS, parentAddress:str=""):
+    async def cancel_all_open_orders(self, symbol:MARKET_SYMBOLS, status: List[ORDER_STATUS], parentAddress:str=""):
         """
             GETs all open orders for the specified symbol, creates a cancellation request 
             for all orders and POSTs the cancel order request to Firefly
             Inputs:
                 - symbol (MARKET_SYMBOLS): Market for which orders are to be cancelled 
+                - status (List[ORDER_STATUS]): status of orders that need to be cancelled 
                 - parentAddress (str): address of parent account, only provided by sub account
             Returns:
                 - dict: response from orders delete API Firefly
@@ -277,7 +278,7 @@ class FireflyClient:
         orders = await self.get_orders({
             "symbol":symbol,
             "parentAddress": parentAddress,
-            "statuses":[ORDER_STATUS.OPEN, ORDER_STATUS.PARTIAL_FILLED]
+            "statuses":status
         })
 
         hashes = []

--- a/src/firefly_exchange_client/client.py
+++ b/src/firefly_exchange_client/client.py
@@ -264,7 +264,7 @@ class FireflyClient:
             auth_required=True
             )
     
-    async def cancel_all_open_orders(self, symbol:MARKET_SYMBOLS, status: List[ORDER_STATUS], parentAddress:str=""):
+    async def cancel_all_orders(self, symbol:MARKET_SYMBOLS, status: List[ORDER_STATUS], parentAddress:str=""):
         """
             GETs all open orders for the specified symbol, creates a cancellation request 
             for all orders and POSTs the cancel order request to Firefly

--- a/src/firefly_exchange_client/client.py
+++ b/src/firefly_exchange_client/client.py
@@ -266,8 +266,9 @@ class FireflyClient:
     
     async def cancel_all_orders(self, symbol:MARKET_SYMBOLS, status: List[ORDER_STATUS], parentAddress:str=""):
         """
-            GETs all open orders for the specified symbol, creates a cancellation request 
-            for all orders and POSTs the cancel order request to Firefly
+            GETs all orders of specified status for the specified symbol, 
+            and creates a cancellation request for all orders and 
+            POSTs the cancel order request to Firefly
             Inputs:
                 - symbol (MARKET_SYMBOLS): Market for which orders are to be cancelled 
                 - status (List[ORDER_STATUS]): status of orders that need to be cancelled 


### PR DESCRIPTION
-Renamed `cancel_all_open_orders` call to `cancel_all_orders` 
- The `cancel_all_orders` method takes an array of `Status` of orders that are to be sent for cancellation
- Updated example
- Bumped version to `v0.2.0`