### PR TITLE
Added parent account to socket connection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "ABNF",
         "aiohttp",
         "ARBITRUM",
         "asyncio",

--- a/examples/16.listening_events_using_sub_account.py
+++ b/examples/16.listening_events_using_sub_account.py
@@ -1,0 +1,82 @@
+'''
+  This example shows how you can listen to user events using sub account
+  On our exchange, a sub account is trading on its parent's position and thus
+  has no position of its own. So when placing orders or listening to position updates
+  the sub account must specify the parent address whose position its listening.
+'''
+import time, sys
+from config import TEST_ACCT_KEY, TEST_NETWORK, TEST_SUB_ACCT_KEY
+from firefly_exchange_client import FireflyClient, Networks, MARKET_SYMBOLS, OrderSignatureRequest, ORDER_SIDE, ORDER_TYPE, SOCKET_EVENTS
+import asyncio
+
+def callback(event):
+    print("Event data: {}\n".format(event))
+
+async def main():
+
+  clientParent = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+  await clientParent.init(True)
+
+  clientChild = FireflyClient(True, Networks[TEST_NETWORK], TEST_SUB_ACCT_KEY)
+  await clientChild.init(True)
+
+  print("Parent: ", clientParent.get_public_address())
+
+  print("Child: ", clientChild.get_public_address())
+
+  # # whitelist sub account
+  status = await clientParent.update_sub_account(MARKET_SYMBOLS.ETH, clientChild.get_public_address(), True)
+  print("Sub account created: {}\n".format(status))
+
+
+  # must open socket before subscribing
+  print("Making socket connection to firefly exchange")
+  await clientChild.socket.open()
+
+  # subscribe to parent's events
+  await clientChild.socket.subscribe_user_update_by_token(clientParent.get_public_address())
+  print("Subscribed to parent's events")
+
+
+  # triggered when status of any user order updates
+  print("Listening to parents position updates")
+  await clientChild.socket.listen(SOCKET_EVENTS.POSITION_UPDATE.value, callback)
+
+  clientChild.add_market(MARKET_SYMBOLS.ETH)
+
+  parent_leverage =  await clientParent.get_user_leverage(MARKET_SYMBOLS.ETH)
+
+  signature_request = OrderSignatureRequest(
+        symbol=MARKET_SYMBOLS.ETH, # sub account is only whitelisted for ETH market
+        maker=clientParent.get_public_address(),  # maker of the order is the parent account
+        price=0,  
+        quantity=0.02,
+        side=ORDER_SIDE.BUY, 
+        orderType=ORDER_TYPE.MARKET,
+        leverage=parent_leverage,
+    )  
+
+  # order is signed using sub account's private key
+  signed_order = clientChild.create_signed_order(signature_request);
+
+  resp = await clientChild.post_signed_order(signed_order)
+
+  print(resp)
+
+  time.sleep(10)
+
+  status = await clientChild.socket.unsubscribe_user_update_by_token(clientParent.get_public_address())
+  print("Unsubscribed from user events: {}".format(status))
+
+  # close socket connection
+  print("Closing sockets!")
+  await clientChild.socket.close()
+
+  await clientChild.apis.close_session()
+
+  await clientParent.apis.close_session()
+
+
+if __name__ == "__main__":
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/firefly_exchange_client/sockets.py
+++ b/src/firefly_exchange_client/sockets.py
@@ -111,11 +111,13 @@ class Sockets:
         except:
             return False
 
-    async def subscribe_user_update_by_token(self,user_token: str=None):
+    async def subscribe_user_update_by_token(self, parent_account: str=None, user_token: str=None):
         """
             Allows user to subscribe to their account updates.
             Inputs:
-                - token: auth token generated when onboarding on firefly
+                - parent_account(str): address of parent account. Only whitelisted 
+                  sub-account can listen to its parent account position updates
+                - token(str): auth token generated when onboarding on firefly
         """
         try:
             if not self.connection_established:
@@ -124,17 +126,20 @@ class Sockets:
             sio.emit("SUBSCRIBE", [
             {
                 "e": SOCKET_EVENTS.USER_UPDATES_ROOM.value,
+                'pa': parent_account,
                 "t": self.token if user_token == None else user_token,
             },
             ])
             return True
-        except:
+        except Exception as e:
+            print(e);
             return False
 
-    async def unsubscribe_user_update_by_token(self,user_token:str=None): 
+    async def unsubscribe_user_update_by_token(self, parent_account: str=None, user_token:str=None): 
         """
             Allows user to unsubscribe to their account updates.
             Inputs:
+                - parent_account(str): address of parent account. Only for sub-accounts
                 - token: auth token generated when onboarding on firefly
         """
         try:
@@ -144,6 +149,7 @@ class Sockets:
             sio.emit("UNSUBSCRIBE", [
             {
                 "e": SOCKET_EVENTS.USER_UPDATES_ROOM.value,
+                'pa': parent_account,
                 "t": self.token if user_token == None else user_token,
             },
             ])

--- a/src/firefly_exchange_client/websocket_client.py
+++ b/src/firefly_exchange_client/websocket_client.py
@@ -101,12 +101,10 @@ class WebsocketClient:
         except:
             return False
 
-    def subscribe_user_update_by_token(self, parent_account: str=None, user_token: str=None):
+    def subscribe_user_update_by_token(self, user_token: str=None):
         """
             Allows user to subscribe to their account updates.
             Inputs:
-                - parent_account(str): address of parent account. Only whitelisted 
-                  sub-account can listen to its parent account position updates
                 - token(str): auth token generated when onboarding on firefly
         """
         try:
@@ -116,7 +114,6 @@ class WebsocketClient:
             self.socket_manager.send_message(json.dumps((["SUBSCRIBE", [
             {
                 "e": SOCKET_EVENTS.USER_UPDATES_ROOM.value,
-                'pa': parent_account,
                 "t": self.token if user_token == None else user_token,
             },
             ]])))
@@ -124,11 +121,10 @@ class WebsocketClient:
         except:
             return False
 
-    def unsubscribe_user_update_by_token(self, parent_account: str=None, user_token:str=None): 
+    def unsubscribe_user_update_by_token(self, user_token:str=None): 
         """
             Allows user to unsubscribe to their account updates.
             Inputs:
-                - parent_account(str): address of parent account. Only for sub-accounts
                 - token: auth token generated when onboarding on firefly
         """
         try:
@@ -138,7 +134,6 @@ class WebsocketClient:
             self.socket_manager.send_message(json.dumps((["UNSUBSCRIBE", [
             {
                 "e": SOCKET_EVENTS.USER_UPDATES_ROOM.value,
-                'pa': parent_account,
                 "t": self.token if user_token == None else user_token,
             },
             ]])))

--- a/src/firefly_exchange_client/websocket_client.py
+++ b/src/firefly_exchange_client/websocket_client.py
@@ -101,11 +101,13 @@ class WebsocketClient:
         except:
             return False
 
-    def subscribe_user_update_by_token(self,user_token: str=None):
+    def subscribe_user_update_by_token(self, parent_account: str=None, user_token: str=None):
         """
             Allows user to subscribe to their account updates.
             Inputs:
-                - token: auth token generated when onboarding on firefly
+                - parent_account(str): address of parent account. Only whitelisted 
+                  sub-account can listen to its parent account position updates
+                - token(str): auth token generated when onboarding on firefly
         """
         try:
             if not self.socket_manager.ws.connected:
@@ -114,6 +116,7 @@ class WebsocketClient:
             self.socket_manager.send_message(json.dumps((["SUBSCRIBE", [
             {
                 "e": SOCKET_EVENTS.USER_UPDATES_ROOM.value,
+                'pa': parent_account,
                 "t": self.token if user_token == None else user_token,
             },
             ]])))
@@ -121,10 +124,11 @@ class WebsocketClient:
         except:
             return False
 
-    def unsubscribe_user_update_by_token(self,user_token:str=None): 
+    def unsubscribe_user_update_by_token(self, parent_account: str=None, user_token:str=None): 
         """
             Allows user to unsubscribe to their account updates.
             Inputs:
+                - parent_account(str): address of parent account. Only for sub-accounts
                 - token: auth token generated when onboarding on firefly
         """
         try:
@@ -134,6 +138,7 @@ class WebsocketClient:
             self.socket_manager.send_message(json.dumps((["UNSUBSCRIBE", [
             {
                 "e": SOCKET_EVENTS.USER_UPDATES_ROOM.value,
+                'pa': parent_account,
                 "t": self.token if user_token == None else user_token,
             },
             ]])))


### PR DESCRIPTION
- Added an optional param `parent_account` to socket connection to allow sub-accounts to subscribe to its parents account events
- A sub-account can specify the address of its parent account to listen to its position update events
- In case the parent account has not whitelisted the account trying to subscribe to its events, the socket connection will still get connected but user won't be able to listen to any events