### PR TITLE
Get Orders Route - Optional API Params

### DIFF
--- a/examples/17.get_orders.py
+++ b/examples/17.get_orders.py
@@ -1,0 +1,58 @@
+'''
+    This example shows how users can get their orders information.
+    The get_orders route provides a number of optional params that can be 
+    mixed together to fetch the exact data that user needs.
+'''
+from config import TEST_ACCT_KEY, TEST_NETWORK
+from firefly_exchange_client import FireflyClient, Networks, MARKET_SYMBOLS, ORDER_STATUS, ORDER_TYPE
+import asyncio
+
+async def main():
+
+    client = FireflyClient(True, Networks[TEST_NETWORK], TEST_ACCT_KEY)
+    await client.init(True)
+
+
+    print("Get all ETH market orders regardless of their type/status")
+    orders = await client.get_orders({
+        "symbol": MARKET_SYMBOLS.ETH,
+        })    
+    print('Received orders: ', len(orders))
+
+    print("Get orders based on status")
+    orders = await client.get_orders({
+        "symbol": MARKET_SYMBOLS.ETH,
+        "statuses": [ORDER_STATUS.OPEN, ORDER_STATUS.PENDING]
+        })    
+    print('Received orders: ', len(orders))
+
+
+    print("Get an order using id")
+    orders = await client.get_orders({
+        "symbol": MARKET_SYMBOLS.ETH,
+        "orderId": 180318
+        })
+    print('Received orders: ', len(orders))
+
+    print("Get orders using hashes")
+    orders = await client.get_orders({
+        "symbol": MARKET_SYMBOLS.ETH,
+        "orderHashes": [
+        "0x21eeb24b0af6832989484e61294db70e8cf8ce0e030c6cfbbb23f3b3d85f9374",
+        "0xd61fe390f6e6d89a884c73927741ba7d2d024e01f65af61f13363403e805e2c0"]
+        })
+    print('Received orders: ', len(orders))
+
+    print("Get only MARKET orders")
+    orders = await client.get_orders({
+        "symbol": MARKET_SYMBOLS.ETH,
+        "orderType": [ORDER_TYPE.MARKET]
+    })
+    print('Received orders: ', len(orders))
+
+    await client.apis.close_session();
+
+
+if __name__ == "__main__":
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "firefly_exchange_client"
-version = "0.2.1"
+version = "0.2.2"
 description = "Library to interact with firefly exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/firefly_exchange_client/client.py
+++ b/src/firefly_exchange_client/client.py
@@ -706,7 +706,7 @@ class FireflyClient:
             Returns:
                 - list: a list of orders 
         """
-        params = extract_enums(params,["symbol","statuses"])
+        params = extract_enums(params,["symbol","statuses", "orderType"])
 
         return await self.apis.get(
             SERVICE_URLS["USER"]["ORDERS"],

--- a/src/firefly_exchange_client/interfaces.py
+++ b/src/firefly_exchange_client/interfaces.py
@@ -134,7 +134,10 @@ class GetUserTradesRequest(TypedDict):
   parentAddress: str # (optional) should be provided by sub account
 
 class GetOrderRequest(GetTransactionHistoryRequest):
-  statuses:List[ORDER_STATUS] # status of orders to be fetched
+  statuses:List[ORDER_STATUS] # (optional) status of orders to be fetched
+  orderId: int #(optional) the id of order to be fetched
+  orderType: List[ORDER_TYPE]; # (optional) type of order Limit/Market
+  orderHashes: List[str] # (optional) hashes of order to be fetched
   parentAddress : str # (optional) should be provided by sub accounts
 
 class GetFundingHistoryRequest(TypedDict):


### PR DESCRIPTION
Updated `GetOrdersRequest` interface to have additional optional parameters:
- `orderType`
- `orderHashes`
- `orderId`

Added example on how `get_orders()` method can be invoked

Bumped version to `v0.2.2`
